### PR TITLE
キャッシュモード 0 の挙動を「オブジェクトの編集中はキャッシュ無効」に変更する

### DIFF
--- a/src/CacheText.lua
+++ b/src/CacheText.lua
@@ -33,7 +33,8 @@ function P.rawmes(message, mode)
   P.key = "CacheText:" .. obj.layer
   P.msg = message
   local c = P.caches[P.key]
-  if (c ~= nil and c.msg ~= P.msg)or(mode == 0) then
+  if (c ~= nil and (c.frame == obj.frame or c.msg ~= P.msg)) or (mode == 0) then
+    -- カーソル位置が変わらずに再描画された（サイズを変更した場合など）か、
     -- テキスト内容が変わったか、キャッシュ無効モードならキャッシュを破棄
     P.del(P.key)
     c = nil
@@ -81,6 +82,7 @@ function P.store(key)
   if obj.index == 0 then
     c = {
       t = os.clock(),
+      frame = obj.frame,
       d = 0,
       msg = P.msg,
       num = obj.num,
@@ -121,6 +123,7 @@ function P.load(key)
   end
   if obj.index == 0 then
     c.t = os.clock()
+    c.frame = obj.frame
     c.d = 0
   end
   local cimg = c.img[obj.index]

--- a/src/CacheText.lua
+++ b/src/CacheText.lua
@@ -18,8 +18,11 @@ function P.del(key)
   P.caches[key] = nil
 end
 
--- message: メッセージ本文
--- mode: 動作モード 0 = 常に最新データを使う / 1 = キャッシュを使う
+-- @param message メッセージ本文
+-- @param mode 動作モード
+--             -1 = 常に最新データを使う
+--              0 = オブジェクト編集中以外はキャッシュを使う
+--              1 = 常にキャッシュを使う
 function P.mes(message, mode)
   -- 拡張編集の GUI 上で入力されたテキストは Shift_JIS の駄目文字への対策が行われるが、
   -- そもそも文字列をダブルクォートで括っていない場合にはゴミになるので除去しておく
@@ -33,8 +36,9 @@ function P.rawmes(message, mode)
   P.key = "CacheText:" .. obj.layer
   P.msg = message
   local c = P.caches[P.key]
-  if (c ~= nil and (c.frame == obj.frame or c.msg ~= P.msg)) or (mode == 0) then
-    -- カーソル位置が変わらずに再描画された（サイズを変更した場合など）か、
+  if c ~= nil and (mode == 0 and c.frame == obj.frame and obj.getoption("gui") or c.msg ~= P.msg)
+  or mode == -1 then
+    -- 編集中カーソル移動せずに再描画された（サイズを変更した場合など）か、
     -- テキスト内容が変わったか、キャッシュ無効モードならキャッシュを破棄
     P.del(P.key)
     c = nil


### PR DESCRIPTION
キャッシュ有効で色やサイズを変更するとすぐに反映されず不定のタイミングで反映される問題を軽減します。
「文字毎に個別オブジェクト」の変更もすぐに反映されるようになっています。